### PR TITLE
define factory() as static

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -24,7 +24,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 	 * 
 	 * @return object
 	 */
-	public function factory() {
+	public static function factory() {
 		static $instance;
 
 		if ( empty( $instance ) ) {


### PR DESCRIPTION
When used with strict error reporting this generates a warning that can be easily fixed by making the factory() method static (or by changing the method call):

Strict Standards: Non-static method EP_Debug_Bar_ElasticPress::factory() should not be called statically in /path/to/plugin/debug-bar-elasticpress/debug-bar-elasticpress.php on line 19

fixes issue #1 