### PR TITLE
Remove stripslashes so that valid JSON displays in the debug output.

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -128,7 +128,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 						<?php if ( ! empty( $query['args']['body'] ) ) : ?>
 							<div clsas="ep-query-body">
 								<strong><?php esc_html_e( 'Query Body:', 'debug-bar' ); ?> <div class="query-body-toggle dashicons"></div></strong>
-								<pre class="query-body"><?php echo esc_html( stripslashes( json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-body"><?php echo esc_html( json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php endif; ?>
 
@@ -138,10 +138,10 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 
 						<div class="ep-query-result">
 							<strong><?php esc_html_e( 'Query Result:', 'debug-bar' ); ?> <div class="query-result-toggle dashicons"></div></strong>
-							<pre class="query-results"><?php echo esc_html( stripslashes( json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+							<pre class="query-results"><?php echo esc_html( json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ); ?></pre>
 						</div>
 					</li><?php
-					
+
 				endforeach;
 
 			?></ol><?php


### PR DESCRIPTION
Currently the debug output does not display valid JSON. By removing stripslashes, the JSON will be valid and the output will still be properly escaped.