### PR TITLE
Feature/add more default log types

### DIFF
--- a/classes/class-ep-query-log.php
+++ b/classes/class-ep-query-log.php
@@ -124,6 +124,8 @@ class EP_Debug_Bar_Query_Log {
 			'delete_index'         => array( $this, 'maybe_log_delete_index' ),
 			'create_pipeline'      => array( $this, 'is_query_error' ),
 			'get_pipeline'         => array( $this, 'is_query_error' ),
+			'query'                => array( $this, 'is_query_error' ),
+			'get_post'             => array( $this, 'is_query_error' ),
 		), $query, $type );
 
 		if ( isset( $allowed_log_types[ $type ] ) ) {

--- a/classes/class-ep-query-log.php
+++ b/classes/class-ep-query-log.php
@@ -125,7 +125,6 @@ class EP_Debug_Bar_Query_Log {
 			'create_pipeline'      => array( $this, 'is_query_error' ),
 			'get_pipeline'         => array( $this, 'is_query_error' ),
 			'query'                => array( $this, 'is_query_error' ),
-			'get_post'             => array( $this, 'is_query_error' ),
 		), $query, $type );
 
 		if ( isset( $allowed_log_types[ $type ] ) ) {


### PR DESCRIPTION
Add `query` as default query log type.
while doing development and debugging, this `query` is often used to see why the ES query failed.