### PR TITLE
Display ElasticPress/ElasticSearch version on panel.

### DIFF
--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -25,6 +25,27 @@ function ep_add_debug_bar_panel( $panels ) {
 add_filter( 'debug_bar_panels', 'ep_add_debug_bar_panel' );
 
 /**
+ * Registers EP and ES versions on panel
+ *
+ * @param $statuses
+ * @return array
+ */
+function ep_add_debug_bar_status( $statuses ) {
+	$statuses[] = array(
+		'ep_version',
+		__( 'ElasticPress Version', 'debug-bar' ),
+		get_option( 'ep_version' ),
+	);
+	$statuses[] = array(
+		'es_version',
+		__( 'ElasticSearch Version', 'debug-bar' ),
+		ep_get_elasticsearch_version(),
+	);
+	return $statuses;
+}
+add_filter( 'debug_bar_statuses', 'ep_add_debug_bar_status' );
+
+/**
  * Add explain=true to elastic post query
  *
  * @param array $formatted_args


### PR DESCRIPTION
Hi @tlovett1 ,

Could you please review this PR which addresses feature #11  ?

This commit adds the current ElasticPress, as well as the current ElasticSearch version. I thought having the current ES version is useful too when showing debug screenshots to help troubleshoot issues on ElasticPress.

This is how the panel currently looks:

![epversion](https://user-images.githubusercontent.com/31049169/49693441-9321b400-fb38-11e8-8530-16aedd94b99d.png)

Thanks!
