### PR TITLE
Add admin-bar deps to assets

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -21,8 +21,8 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 	 * Enqueue scripts for front end and admin
 	 */
 	public function enqueue_scripts_styles() {
-		wp_enqueue_script( 'debug-bar-elasticpress', plugins_url( '../assets/js/main.js' , __FILE__ ), array( 'jquery' ), EP_DEBUG_VERSION, true );
-		wp_enqueue_style( 'debug-bar-elasticpress', plugins_url( '../assets/css/main.css' , __FILE__ ), array(), EP_DEBUG_VERSION );
+		wp_enqueue_script( 'debug-bar-elasticpress', plugins_url( '../assets/js/main.js' , __FILE__ ), array( 'jquery', 'admin-bar' ), EP_DEBUG_VERSION, true );
+		wp_enqueue_style( 'debug-bar-elasticpress', plugins_url( '../assets/css/main.css' , __FILE__ ), array( 'admin-bar' ), EP_DEBUG_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Adds admin bar script and style dependencies to assets. The plugin depends on debug bar/query monitor, and therefore the admin bar.

### Benefits

While there's nothing _functionally_ requiring these dependencies be declared, it does improve compatibility with AMP plugin validation. [See this article.](https://weston.ruter.net/2019/09/24/integrating-with-amp-dev-mode-in-wordpress/) 

### Alternate Designs

If you think there's a better way of approaching that (explicitly adding amp devmode tags within the plugin, for example, I'm open to that.

### Possible Drawbacks

None?

### Verification Process

EP integration still functions, AMP no longer throws validation warnings.

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
