### PR TITLE
Don't strip slashes when outputting JSON body objects

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -137,7 +137,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 						<?php if ( ! empty( $query['args']['body'] ) ) : ?>
 							<div clsas="ep-query-body">
 								<strong><?php esc_html_e( 'Query Body:', 'debug-bar' ); ?> <div class="query-body-toggle dashicons"></div></strong>
-								<pre class="query-body"><?php echo esc_html( stripslashes( json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-body"><?php echo esc_html( json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php endif; ?>
 
@@ -149,7 +149,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 
 							<div class="ep-query-result">
 								<strong><?php esc_html_e( 'Query Result:', 'debug-bar' ); ?> <div class="query-result-toggle dashicons"></div></strong>
-								<pre class="query-results"><?php echo esc_html( stripslashes( json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-results"><?php echo esc_html( json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php else : ?>
 							<div class="ep-query-response-code">
@@ -157,7 +157,7 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 							</div>
 							<div clsas="ep-query-errors">
 								<strong><?php esc_html_e( 'Errors:', 'debug-bar' ); ?> <div class="query-errors-toggle dashicons"></div></strong>
-								<pre class="query-errors"><?php echo esc_html( stripslashes( json_encode( $query['request']->errors, JSON_PRETTY_PRINT ) ) ); ?></pre>
+								<pre class="query-errors"><?php echo esc_html( json_encode( $query['request']->errors, JSON_PRETTY_PRINT ) ); ?></pre>
 							</div>
 						<?php endif; ?>
 						<a class="copy-curl" data-request="<?php echo esc_attr( addcslashes( $curl_request, '"' ) ); ?>">Copy cURL Request</a>


### PR DESCRIPTION
### Description of the Change

This removes the `stripslashes` escaping from each of the pre-formatted JSON blobs in the ElasticPress Query Monitor panel: "Query Body", "Query Result", and "Query Errors".

JSON is intended to be a "safe" format, and stripping slashes here doesn't add any security that I can see.

It does - however - break copying and pasting of these blocks. If I search for やばい on an ElasticPress-powered site, and then copy the query body to paste into Kibana to explore further, I would want to get

```
  "query": "\u3084\u3070\u3044",
```

rather than

```
  "query": "u3084u3070u3044",
```

### What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

I've tested this by running searches containing Unicode characters on sites using ElasticPress, opening up the debug bar panel, and inspecting the json blobs. I've also tried to get malicious or unsafe strings into search terms (i.e. containing backslashes, quotes, or other characters than might break json output). I have not found any, and the display in the debug bar panel matches what I would expect.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
