### PR TITLE
Display EP and ES versions

### DIFF
--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -48,6 +48,9 @@ function ep_add_debug_bar_stati( $stati ) {
 	) {
 		$elasticsearch_version = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
 	}
+	if ( function_exists( '\ElasticPress\Utils\is_epio' ) && \ElasticPress\Utils\is_epio() ) {
+		$elasticsearch_version = esc_html__( 'ElasticPress.io Managed Platform', 'debug-bar-elasticpress' );
+	}
 	$stati[] = array(
 		'es_version',
 		esc_html__( 'Elasticsearch Version', 'debug-bar-elasticpress' ),

--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -26,8 +26,36 @@ function ep_add_debug_bar_panel( $panels ) {
 	$panels[] = new EP_Debug_Bar_ElasticPress();
 	return $panels;
 }
-
 add_filter( 'debug_bar_panels', 'ep_add_debug_bar_panel' );
+
+/**
+ * Register status
+ *
+ * @param array $stati Debug Bar Stati
+ * @return array
+ */
+function ep_add_debug_bar_stati( $stati ) {
+	$stati[] = array(
+		'ep_version',
+		esc_html__( 'ElasticPress Version', 'debug-bar-elasticpress' ),
+		defined( 'EP_VERSION' ) ? EP_VERSION : '',
+	);
+
+	$elasticsearch_version = '';
+	if (
+		class_exists( '\ElasticPress\Elasticsearch' ) &&
+		method_exists( \ElasticPress\Elasticsearch::factory(), 'get_elasticsearch_version' )
+	) {
+		$elasticsearch_version = \ElasticPress\Elasticsearch::factory()->get_elasticsearch_version();
+	}
+	$stati[] = array(
+		'es_version',
+		esc_html__( 'Elasticsearch Version', 'debug-bar-elasticpress' ),
+		$elasticsearch_version,
+	);
+	return $stati;
+}
+add_filter( 'debug_bar_statuses', 'ep_add_debug_bar_stati' );
 
 /**
  * Add explain=true to elastic post query


### PR DESCRIPTION
### Description of the Change

Display ElasticPress and Elasticsearch versions:

![image](https://user-images.githubusercontent.com/184628/125979317-d999a2fe-4838-4f76-8ad4-942fa915605d.png)

### Applicable Issues

Closes #11 and #20

### Changelog Entry

Props to @oscarssanchez for the original code in #20.