### PR TITLE
Log bulk index errors

### DIFF
--- a/classes/class-ep-debug-bar-query-output.php
+++ b/classes/class-ep-debug-bar-query-output.php
@@ -102,7 +102,16 @@ class EP_Debug_Bar_Query_Output {
 			<?php if ( ! empty( $query['args']['body'] ) ) : ?>
 				<div class="ep-query-body">
 					<strong><?php esc_html_e( 'Query Body:', 'debug-bar-elasticpress' ); ?> <div class="query-body-toggle dashicons"></div></strong>
-					<pre class="query-body"><?php echo esc_html( stripslashes( wp_json_encode( json_decode( $query['args']['body'], true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+					<?php
+					// Bulk indexes are not "valid" JSON, for example.
+					$body = json_decode( $query['args']['body'], true );
+					if ( json_last_error() === JSON_ERROR_NONE ) {
+						$body = wp_json_encode( $body, JSON_PRETTY_PRINT );
+					} else {
+						$body = $query['args']['body'];
+					}
+					?>
+					<pre class="query-body"><?php echo esc_html( stripslashes( $body ) ); ?></pre>
 				</div>
 			<?php endif; ?>
 

--- a/classes/class-ep-query-log.php
+++ b/classes/class-ep-query-log.php
@@ -120,6 +120,22 @@ class EP_Debug_Bar_Query_Log {
 	}
 
 	/**
+	 * Check the request body, as usually bulk indexing does not return a status error.
+	 *
+	 * @since 2.0.1
+	 * @param array $query Remote request arguments
+	 * @return boolean
+	 */
+	public function is_bulk_index_error( $query ) {
+		if ( $this->is_query_error( $query ) ) {
+			return true;
+		}
+
+		$request_body = json_decode( wp_remote_retrieve_body( $query['request'] ), true );
+		return ! empty( $request_body['errors'] );
+	}
+
+	/**
 	 * Conditionally save a query to the log which is stored in options. This is a big performance hit so be careful.
 	 *
 	 * @param array  $query Remote request arguments
@@ -150,6 +166,7 @@ class EP_Debug_Bar_Query_Log {
 				'put_mapping'          => array( $this, 'is_query_error' ),
 				'delete_network_alias' => array( $this, 'is_query_error' ),
 				'create_network_alias' => array( $this, 'is_query_error' ),
+				'bulk_index'           => array( $this, 'is_bulk_index_error' ),
 				'bulk_index_posts'     => array( $this, 'is_query_error' ),
 				'delete_index'         => array( $this, 'maybe_log_delete_index' ),
 				'create_pipeline'      => array( $this, 'is_query_error' ),


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Start logging errored bulk_index queries. This is the type of query used when syncing via Dashboard, saving a post or using WP-CLI without the --nobulk flag.

### Applicable Issues

Closes #40 

### Changelog Entry

Added: Log of bulk_index requests.
