### PR TITLE
Display a warning when EP is indexing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,10 @@
+.ep-debug-bar-warning {
+	background-color: #ffffe0;
+	border: 1px solid #e6db55;
+	clear: both;
+	padding: 0.5em 10px;
+}
+
 .ep-queries-debug .dashicons {
 	cursor: pointer;
 }

--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -92,6 +92,13 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 			);
 			?>
 		</h2>
+
+		<?php if ( function_exists( '\ElasticPress\Utils\is_indexing' ) && \ElasticPress\Utils\is_indexing() ) : ?>
+			<div class="ep-debug-bar-warning">
+				<?php esc_html_e( 'ElasticPress is currently indexing.', 'debug-bar-elasticpress' ); ?>
+			</div>
+		<?php endif; ?>
+
 		<?php if ( empty( $queries ) ) : ?>
 			<ol class="wpd-queries">
 				<li><?php esc_html_e( 'No queries to show', 'debug-bar-elasticpress' ); ?></li>


### PR DESCRIPTION
### Description of the Change

The title says it all. An image of how it looks like now:

![image](https://user-images.githubusercontent.com/184628/125987405-4f139986-2a77-4489-8e01-35b988867997.png)

### Applicable Issues

Closes #23

### Changelog Entry

Added: Warning when ElasticPress is indexing
