### PR TITLE
Optimize assets loading

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -36,8 +36,12 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 	 * Enqueue scripts for front end and admin
 	 */
 	public function enqueue_scripts_styles() {
-		wp_enqueue_script( 'debug-bar-elasticpress', plugins_url( '../assets/js/main.js', __FILE__ ), array( 'wp-dom-ready' ), EP_DEBUG_VERSION, true );
-		wp_enqueue_style( 'debug-bar-elasticpress', plugins_url( '../assets/css/main.css', __FILE__ ), array(), EP_DEBUG_VERSION );
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		wp_enqueue_script( 'debug-bar-elasticpress', EP_DEBUG_URL . 'assets/js/main.js', array( 'wp-dom-ready' ), EP_DEBUG_VERSION, true );
+		wp_enqueue_style( 'debug-bar-elasticpress', EP_DEBUG_URL . 'assets/css/main.css', array(), EP_DEBUG_VERSION );
 	}
 
 	/**

--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -14,6 +14,7 @@
  */
 
 define( 'EP_DEBUG_VERSION', '2.0.0' );
+define( 'EP_DEBUG_URL', plugin_dir_url( __FILE__ ) );
 
 /**
  * Register panel


### PR DESCRIPTION
### Description of the Change

As described in #26, while using the plugin with Query Monitor, CSS and JS files are always included. Although that happens due to Query Monitor not checking if Debug Bar would be visible or not, this change shouldn't bring any side-effect.

### Benefits

Avoid loading CSS and JS files unnecessarily.

### Applicable Issues

Closes #26

### Changelog Entry

Changed: only load CSS and JS files for logged-in users.