### PR TITLE
Prep release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
-## [2.1.0] - 2021-08-?
+## [2.1.0] - 2021-08-09
 
 ### Added
 * ElasticPress and Elasticsearch versions. Props to [@oscarssanchez](https://github.com/oscarssanchez) and [@felipeelia](https://github.com/felipeelia) via [#43](https://github.com/10up/debug-bar-elasticpress/pull/43)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
-## [2.0.0]
+## [2.1.0] - 2021-08-?
+
+### Added
+* ElasticPress and Elasticsearch versions. Props to [@oscarssanchez](https://github.com/oscarssanchez) and [@felipeelia](https://github.com/felipeelia) via [#43](https://github.com/10up/debug-bar-elasticpress/pull/43)
+* Log of bulk_index requests. Props [@felipeelia](https://github.com/felipeelia) via [#44](https://github.com/10up/debug-bar-elasticpress/pull/44)
+* Warning when ElasticPress is indexing. Props [@nathanielks](https://github.com/nathanielks) and [@felipeelia](https://github.com/felipeelia) via [#45](https://github.com/10up/debug-bar-elasticpress/pull/45)
+
+### Changed
+* Only load CSS and JS files for logged-in users. Props [@cbratschi](https://github.com/cbratschi) and [@felipeelia](https://github.com/felipeelia) via [#47](https://github.com/10up/debug-bar-elasticpress/pull/47)
+
+## [2.0.0] - 2021-04-19
 
 This release drops the support for older versions of WordPress Core, ElasticPress and Debug Bar.
 
@@ -10,27 +20,28 @@ This release drops the support for older versions of WordPress Core, ElasticPres
 * Fixed Query Logs in EP Dashboard [@felipeelia](https://github.com/felipeelia)
 * Fixed typo from "clsas" to "class" in the query output. Props [@Rahmon](https://github.com/Rahmon) 
 
-## [1.4]
+## [1.4] - 2019-03-01
 * Support ElasticPress 3.0+
 
-## [1.3]
+## [1.3] - 2017-08-23
 * Add query log
 
-## [1.2]
+## [1.2] - 2017-03-15
 * Show query errors (i.e. cURL timeout)
 * Add ?explain to query if GET param is set
 
-## [1.1.1]
+## [1.1.1] - 2016-12-13
 * Only show query body if it exits
 
-## [1.1]
+## [1.1] - 2016-07-25
 * Improve formatting
 * Show original query args (EP 2.1+)
 
-## [1.0]
+## [1.0] - 2016-01-20
 * Initial release
 
 [Unreleased]: https://github.com/10up/debug-bar-elasticpress/compare/trunk...develop
+[2.1.0]: https://github.com/10up/debug-bar-elasticpress/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/10up/debug-bar-elasticpress/compare/1.4...2.0.0
 [1.4]: https://github.com/10up/debug-bar-elasticpress/compare/1.3...1.4
 [1.3]: https://github.com/10up/debug-bar-elasticpress/compare/1.2...1.3

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -12,7 +12,7 @@ The following individuals are responsible for curating the list of issues, respo
 
 Thank you to all the people who have already contributed to this repository via bug reports, code, design, ideas, project management, translation, testing, etc.
 
-[Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Ivan Kristianto (@ivankristianto)](https://github.com/ivankristianto), [Allan Collins (@allan23)](https://github.com/allan23), [Eugene Manuilov (@eugene-manuilov)](https://github.com/eugene-manuilov), [Ricardo Moraleida (@moraleida)](https://github.com/moraleida), [Andreas Ek @ekandreas](https://github.com/ekandreas), [Nathaniel @nathanielks](https://github.com/nathanielks), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Felipe Elia (@felipeelia)](https://github.com/felipeelia), and [Ramon Ahnert @Rahmon](https://github.com/Rahmon).
+[Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Ivan Kristianto (@ivankristianto)](https://github.com/ivankristianto), [Allan Collins (@allan23)](https://github.com/allan23), [Eugene Manuilov (@eugene-manuilov)](https://github.com/eugene-manuilov), [Ricardo Moraleida (@moraleida)](https://github.com/moraleida), [Andreas Ek (@ekandreas)](https://github.com/ekandreas), [Nathaniel (@nathanielks)](https://github.com/nathanielks), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Felipe Elia (@felipeelia)](https://github.com/felipeelia), [Ramon Ahnert (@Rahmon)](https://github.com/Rahmon), [Oscar Sanchez S. (@oscarssanchez)](https://github.com/oscarssanchez), [Nathaniel (@nathanielks)](https://github.com/nathanielks), and [Christoph Bratschi (@cbratschi)](https://github.com/cbratschi).
 
 ## Libraries
 

--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -4,7 +4,7 @@
  * Plugin URI:   https://wordpress.org/plugins/debug-bar-elasticpress
  * Description:  Extends the debug bar plugin for ElasticPress queries.
  * Author:       10up
- * Version:      2.0.0
+ * Version:      2.1.0
  * Author URI:   https://10up.com
  * Requires PHP: 5.4
  * License:      GPLv2
@@ -13,7 +13,7 @@
  * @package DebugBarElasticPress
  */
 
-define( 'EP_DEBUG_VERSION', '2.0.0' );
+define( 'EP_DEBUG_VERSION', '2.1.0' );
 define( 'EP_DEBUG_URL', plugin_dir_url( __FILE__ ) );
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-bar-elasticpress",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-bar-elasticpress",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Extends the Debug Bar plugin for ElasticPress queries.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: debug, debug bar, elasticpress, elasticsearch
 Requires at least: 4.6
 Tested up to: 5.8
 Requires PHP: 5.4
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,6 +26,16 @@ Adds an [ElasticPress](https://wordpress.org/plugins/elasticpress) panel to the 
 3. Install the plugin in WordPress.
 
 == Changelog ==
+
+= 2.1.0 =
+
+Added:
+* ElasticPress and Elasticsearch versions. Props to [@oscarssanchez](https://github.com/oscarssanchez) and [@felipeelia](https://github.com/felipeelia) via [#43](https://github.com/10up/debug-bar-elasticpress/pull/43)
+* Log of bulk_index requests. Props [@felipeelia](https://github.com/felipeelia) via [#44](https://github.com/10up/debug-bar-elasticpress/pull/44)
+* Warning when ElasticPress is indexing. Props [@nathanielks](https://github.com/nathanielks) and [@felipeelia](https://github.com/felipeelia) via [#45](https://github.com/10up/debug-bar-elasticpress/pull/45)
+
+Changed:
+* Only load CSS and JS files for logged-in users. Props [@cbratschi](https://github.com/cbratschi) and [@felipeelia](https://github.com/felipeelia) via [#47](https://github.com/10up/debug-bar-elasticpress/pull/47)
 
 = 2.0.0 =
 This release drops the support for older versions of WordPress Core, ElasticPress and Debug Bar.


### PR DESCRIPTION
### Release instructions

- [x] Branch: Starting from develop, cut a release branch named release/X.Y.Z for your changes.
- [x] Version bump: Bump the version number in debug-bar-elasticpress.php, package.json, readme.txt, README.md, and any other relevant files if it does not already reflect the version being released. In debug-bar-elasticpress.php update both the plugin "Version:" property and the plugin EP_DEBUG_VERSION constant.
- [x] Changelog: Add/update the changelog in CHANGELOG.md and readme.txt, ensuring to link the [X.Y.Z] release reference in the footer of CHANGELOG.md (e.g., https://github.com/10up/debug-bar-elasticpress/compare/X.Y.Z-1...X.Y.Z).
- [x] Props: Update CREDITS.md file with any new contributors, confirm maintainers are accurate.
- [x] Readme updates: Make any other readme changes as necessary. README.md is geared toward GitHub and readme.txt contains WordPress.org-specific content. The two are slightly different.
- [x] New files: Check to be sure any new files/paths that are unnecessary in the production version are included in .gitattributes.
- [x] Merge: Merge the release branch/PR into develop, then make a non-fast-forward merge from develop into trunk (git checkout trunk && git merge --no-ff develop). trunk contains the stable development version.
- [x] Test: While still on the trunk branch, test for functionality locally.
- [x] Push: Push your trunk branch to GitHub (e.g. git push origin trunk).
- [x] Release: Create a new release, naming the tag and the release with the new version number, and targeting the trunk branch. Paste the release changelog from CHANGELOG.md into the body of the release and include a link to the closed issues on the milestone.
- [x] SVN: Wait for the GitHub Action to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
- [x] Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/debug-bar-elasticpress/. This may take a few minutes.
- [x] Close milestone: Edit the milestone with release date (in the Due date (optional) field) and link to GitHub release (in the Description field), then close the milestone.
- [x] Punt incomplete items: If any open issues or PRs which were milestoned for X.Y.Z do not make it into the release, update their milestone to X.Y.Z+1, X.Y+1.0, X+1.0.0 or Future Release.