### PR TITLE
Don't remove slashes while outputting JSON objects

### DIFF
--- a/classes/QueryOutput.php
+++ b/classes/QueryOutput.php
@@ -151,7 +151,7 @@ class QueryOutput {
 			<?php else : ?>
 				<div class="ep-query-errors">
 					<strong><?php esc_html_e( 'Errors:', 'debug-bar-elasticpress' ); ?> <div class="query-errors-toggle dashicons"></div></strong>
-					<pre class="query-errors"><?php echo esc_html( stripslashes( wp_json_encode( $query['request']->errors, JSON_PRETTY_PRINT ) ) ); ?></pre>
+					<pre class="query-errors"><?php echo esc_html( wp_json_encode( $query['request']->errors, JSON_PRETTY_PRINT ) ); ?></pre>
 				</div>
 			<?php endif; ?>
 
@@ -218,7 +218,7 @@ class QueryOutput {
 						$body = $query['args']['body'];
 					}
 					?>
-					<pre class="query-body"><?php echo esc_html( stripslashes( $body ) ); ?></pre>
+					<pre class="query-body"><?php echo esc_html( $body ); ?></pre>
 				</div>
 			<?php endif; ?>
 
@@ -233,7 +233,7 @@ class QueryOutput {
 				</div>
 				<div class="ep-query-result">
 					<strong><?php esc_html_e( 'Query Result:', 'debug-bar-elasticpress' ); ?> <div class="query-result-toggle dashicons"></div></strong>
-					<pre class="query-results"><?php echo esc_html( stripslashes( wp_json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ) ); ?></pre>
+					<pre class="query-results"><?php echo esc_html( wp_json_encode( json_decode( $result, true ), JSON_PRETTY_PRINT ) ); ?></pre>
 				</div>
 			<?php else : ?>
 				<div class="ep-query-response-code">


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Avoid removing `\`, so JSON objects are still valid. Currently, if searching for `"posts"`' (with double quotes), the query result will have `""post""` instead `"\"post\""` (a valid value in a JSON object)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #27
Closes #12

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed - Unnecessary stripslashes call when outputting JSON objects.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @felipeelia @goldenapples, and @mattonomics

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
