### PR TITLE
Remove "Requires Plugins" plugin header

### DIFF
--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -4,7 +4,6 @@
  * Plugin URI:        https://wordpress.org/plugins/debug-bar-elasticpress
  * Description:       Extends the Query Monitor and Debug Bar plugins for ElasticPress queries.
  * Version:           3.1.1
- * Requires Plugins:  elasticpress
  * Requires at least: 5.6
  * Requires PHP:      7.0
  * Author:            10up


### PR DESCRIPTION
Consider removing the required plugin entry in readme.txt. This prevents the debug bar elasticpress plugin from being activated if the elasticpress plugin is installed as an mu-plugin.

https://core.trac.wordpress.org/ticket/60692

(Another side effect of this is that you cannot deactivate the elasticpress plugin unless you also deactivate the debug bar extension, can be a bit annoying when debugging things).

