### PR TITLE
Add compatibility with Query Monitor 4

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -10,11 +10,15 @@
 }
 
 .ep-queries-debug .dashicons {
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-top: 5px solid currentColor;
 	cursor: pointer;
-}
-
-.ep-queries-debug .dashicons::before {
-	content: "\f140";
+	display: inline-block;
+	height: 0;
+	margin-left: 5px;
+	vertical-align: middle;
+	width: 0;
 }
 
 .ep-queries-debug .hide-query-results .query-results,
@@ -33,12 +37,13 @@
 	background-color: white;
 }
 
-.ep-queries-debug .hide-query-results .query-result-toggle::before,
-.ep-queries-debug .hide-query-args .query-args-toggle::before,
-.ep-queries-debug .hide-query-headers .query-headers-toggle::before,
-.ep-queries-debug .hide-query-errors .query-errors-toggle::before,
-.ep-queries-debug .hide-query-body .query-body-toggle::before {
-	content: "\f142";
+.ep-queries-debug .hide-query-results .query-result-toggle,
+.ep-queries-debug .hide-query-args .query-args-toggle,
+.ep-queries-debug .hide-query-headers .query-headers-toggle,
+.ep-queries-debug .hide-query-errors .query-errors-toggle,
+.ep-queries-debug .hide-query-body .query-body-toggle {
+	border-bottom: 5px solid currentColor;
+	border-top: none;
 }
 
 .ep-queries-debug .ep-query-failed .ep-query-response-code {
@@ -55,17 +60,9 @@
 }
 
 .ep-queries-debug-container .copy-curl {
-	border-color: #000;
-	border-radius: 3px;
-	border-style: solid;
-	border-width: 1px;
-	color: #000;
 	cursor: pointer;
 	display: inline-block;
 	font-size: 13px;
-	line-height: 2.1538;
-	min-height: 30px;
-	padding: 0 10px;
 	text-decoration: none;
 }
 
@@ -85,7 +82,7 @@
 	background: #f6f7f7 !important;
 	border: 1px solid #2271b1 !important;
 	border-radius: 3px !important;
-	
+
 	/* Overriding some Debug Bar "important" rules */
 	color: #2271b1 !important;
 	cursor: pointer;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -15,10 +15,8 @@
 	border-top: 5px solid currentColor;
 	cursor: pointer;
 	display: inline-block;
-	height: 0;
 	margin-left: 5px;
 	vertical-align: middle;
-	width: 0;
 }
 
 .ep-queries-debug .hide-query-results .query-results,

--- a/classes/CommonPanel.php
+++ b/classes/CommonPanel.php
@@ -36,14 +36,27 @@ class CommonPanel {
 	/**
 	 * Enqueue scripts for front end and admin
 	 */
-	public function enqueue_scripts_styles() {
+	public function enqueue_scripts(): void {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
 
-		wp_enqueue_script( 'debug-bar-elasticpress', EP_DEBUG_URL . 'assets/js/main.js', array( 'wp-dom-ready', 'clipboard' ), EP_DEBUG_VERSION, true );
-		wp_enqueue_style( 'debug-bar-elasticpress', EP_DEBUG_URL . 'assets/css/main.css', array(), EP_DEBUG_VERSION );
+		wp_enqueue_script( 'debug-bar-elasticpress', EP_DEBUG_URL . 'assets/js/main.js', [ 'wp-dom-ready', 'clipboard' ], EP_DEBUG_VERSION, true );
 	}
+
+	/**
+	 * Enqueue styles for front end and admin
+	 *
+	 * @since 3.1.0
+	 */
+	public function enqueue_styles(): void {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		wp_enqueue_style( 'debug-bar-elasticpress', EP_DEBUG_URL . 'assets/css/main.css', [], EP_DEBUG_VERSION );
+	}
+
 
 	/**
 	 * Show the contents of the panel

--- a/classes/CommonPanel.php
+++ b/classes/CommonPanel.php
@@ -36,7 +36,7 @@ class CommonPanel {
 	/**
 	 * Enqueue scripts for front end and admin
 	 */
-	public function enqueue_scripts(): void {
+	public function enqueue_scripts() {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
@@ -49,7 +49,7 @@ class CommonPanel {
 	 *
 	 * @since 3.1.0
 	 */
-	public function enqueue_styles(): void {
+	public function enqueue_styles() {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}

--- a/classes/EP_Debug_Bar_ElasticPress.php
+++ b/classes/EP_Debug_Bar_ElasticPress.php
@@ -38,14 +38,15 @@ class EP_Debug_Bar_ElasticPress extends \Debug_Bar_Panel {
 		$this->title( esc_html__( 'ElasticPress', 'debug-bar-elasticpress' ) );
 
 		$this->common_panel = new \DebugBarElasticPress\CommonPanel();
-		$this->common_panel->enqueue_scripts_styles();
+		$this->common_panel->enqueue_scripts();
+		$this->common_panel->enqueue_styles();
 	}
 
 	/**
 	 * Enqueue scripts for front end and admin
 	 */
 	public function enqueue_scripts_styles() {
-		_deprecated_function( __METHOD__, '3.1.0', 'DebugBarElasticPress\EP_Panel::enqueue_scripts_styles()' );
+		_deprecated_function( __METHOD__, '3.1.0', 'DebugBarElasticPress\EP_Panel::enqueue_scripts() and DebugBarElasticPress\EP_Panel::enqueue_styles()' );
 	}
 
 	/**

--- a/classes/QueryLog.php
+++ b/classes/QueryLog.php
@@ -478,7 +478,9 @@ class QueryLog {
 			return;
 		}
 
-		( new CommonPanel() )->enqueue_scripts_styles();
+		$common_panel = new CommonPanel();
+		$common_panel->enqueue_scripts();
+		$common_panel->enqueue_styles();
 	}
 
 	/**

--- a/classes/QueryMonitorOutput.php
+++ b/classes/QueryMonitorOutput.php
@@ -66,7 +66,7 @@ class QueryMonitorOutput extends \QM_Output_Html {
 	 */
 	protected function output_styles() {
 		printf(
-			'<link rel="stylesheet" href="%s">',
+			'<link rel="stylesheet" href="%s">', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 			esc_url( EP_DEBUG_URL . 'assets/css/main.css?ver=' . EP_DEBUG_VERSION )
 		);
 	}

--- a/classes/QueryMonitorOutput.php
+++ b/classes/QueryMonitorOutput.php
@@ -50,11 +50,25 @@ class QueryMonitorOutput extends \QM_Output_Html {
 	 */
 	public function output() {
 		?>
+		<?php $this->output_styles(); ?>
 		<div class="qm qm-non-tabular qm-debug-bar qm-panel-show" id="<?php echo esc_attr( $this->collector->id() ); ?>">
 			<?php $this->render_summary(); ?>
 			<?php $this->common_panel->render(); ?>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Output Query Monitor styles so they apply correctly within the Shadow DOM panel.
+	 *
+	 * @since 3.2.0
+	 * @return void
+	 */
+	protected function output_styles() {
+		printf(
+			'<link rel="stylesheet" href="%s">',
+			esc_url( EP_DEBUG_URL . 'assets/css/main.css?ver=' . EP_DEBUG_VERSION )
+		);
 	}
 
 	/**

--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -67,7 +67,7 @@ function setup() {
 	if ( class_exists( '\QM_Collectors' ) ) {
 		\QM_Collectors::add( new QueryMonitorCollector() );
 		add_filter( 'qm/outputter/html', $n( 'register_qm_output' ) );
-		add_action( 'qm/output/enqueued-assets', [ new CommonPanel(), 'enqueue_scripts_styles' ] );
+		add_action( 'qm/output/enqueued-assets', [ new CommonPanel(), 'enqueue_scripts' ] );
 	} else {
 		add_filter( 'debug_bar_panels', $n( 'add_debug_bar_panel' ) );
 		add_filter( 'debug_bar_statuses', $n( 'add_debug_bar_stati' ) );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR adds compatibility with Query Monitor 4. Query Monitor 4 loads the frontend within the Shadow DOM, which prevents styles from being applied to elements.

This PR ensures the styles

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #117 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Ensure plugin works fine with Query Monitor 3 and 4.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Query Monitor 4 support

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
