### PR TITLE
Bump Requires PHP to 7.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
         coverage: none
 
     - name: PHPCS check
-      run: './vendor/bin/phpcs . -q --report=checkstyle --runtime-set testVersion 7.0- | cs2pr'
+      run: './vendor/bin/phpcs . -q --report=checkstyle --runtime-set testVersion 7.4- | cs2pr'
 
     - name: PHP Compatibility Check
       run: composer run check-php-compat

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Requirements
 
 * [ElasticPress](https://wordpress.org/plugins/elasticpress/) 4.4.0+
-* PHP 7.0+
+* PHP 7.4+
 * Optional: [Debug Bar](https://wordpress.org/plugins/debug-bar/) 1.0+ or [Query Monitor](https://wordpress.org/plugins/query-monitor/)
 
 ## Usage

--- a/classes/QueryMonitorOutput.php
+++ b/classes/QueryMonitorOutput.php
@@ -61,7 +61,7 @@ class QueryMonitorOutput extends \QM_Output_Html {
 	/**
 	 * Output Query Monitor styles so they apply correctly within the Shadow DOM panel.
 	 *
-	 * @since 3.2.0
+	 * @since 4.2.0
 	 * @return void
 	 */
 	protected function output_styles() {

--- a/classes/QueryMonitorOutput.php
+++ b/classes/QueryMonitorOutput.php
@@ -61,7 +61,7 @@ class QueryMonitorOutput extends \QM_Output_Html {
 	/**
 	 * Output Query Monitor styles so they apply correctly within the Shadow DOM panel.
 	 *
-	 * @since 4.2.0
+	 * @since 4.0.0
 	 * @return void
 	 */
 	protected function output_styles() {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.4"
   },
   "license": ["GPL-2.0-only"],
   "require-dev": {
@@ -24,7 +24,7 @@
   "scripts": {
     "lint": "phpcs debug-bar-elasticpress.php classes",
     "lint-fix": "phpcbf debug-bar-elasticpress.php classes",
-    "check-php-compat": "phpcs debug-bar-elasticpress.php classes --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-"
+    "check-php-compat": "phpcs debug-bar-elasticpress.php classes --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76cd4a13f565d0bcb01942f664b9ddca",
+    "content-hash": "8b703da2f4e5a1716f478f5e64903412",
     "packages": [],
     "packages-dev": [
         {
@@ -760,8 +760,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/debug-bar-elasticpress.php
+++ b/debug-bar-elasticpress.php
@@ -5,7 +5,7 @@
  * Description:       Extends the Query Monitor and Debug Bar plugins for ElasticPress queries.
  * Version:           3.1.1
  * Requires at least: 5.6
- * Requires PHP:      7.0
+ * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com
  * License:           GPLv2

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: tlovett1, 10up
 Tags: debug, debug bar, elasticpress, elasticsearch
 Requires at least: 4.6
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.4
 Stable tag: 3.1.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -20,7 +20,7 @@ Alternatively, go to ElasticPress > Query Log and set it to record ElasticPress 
 
 * [ElasticPress 4.4.0+](https://wordpress.org/plugins/elasticpress)
 * [Debug Bar 1.0+](https://wordpress.org/plugins/debug-bar/)
-* PHP 7.0+
+* PHP 7.4+
 
 == Installation ==
 1. Install [ElasticPress](https://wordpress.org/plugins/elasticpress).


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR bumps the required PHP version to 7.4

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #121 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump Requires PHP to 7.4

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
