### PR TITLE
Fix: Query Log “Keep Enabled” setting not working.

### DIFF
--- a/classes/QueryLog.php
+++ b/classes/QueryLog.php
@@ -613,9 +613,9 @@ class QueryLog {
 	 * @since 3.1.0
 	 */
 	public function maybe_disable() {
-		$enabled = Utils\get_option( 'ep_enable_logging' );
+		$enabled = intval( Utils\get_option( 'ep_enable_logging' ) );
 
-		$is_time_limit = ! empty( $enabled ) && ! in_array( $enabled, [ '0', 0, '-1' ], true );
+		$is_time_limit = ! empty( $enabled ) && ! in_array( $enabled, [ 0, -1 ], true );
 		if ( ! $is_time_limit || $enabled > wp_date( 'U' ) ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the Query Log “Keep Enabled” setting was automatically reverting to “Disable” on a single site. The issue occurred because, on a single site, `Utils\get_option( 'ep_enable_logging' )` returned the integer `-1`, whereas when the plugin was network-activated, it returned the string `"-1"`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Query Log “Keep Enabled” setting not working.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
